### PR TITLE
ADD a list of BugSigDB PD studies and their curation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ With the help of Svetlana and the Outreachy initiative, we are adding 8 new shot
 | 3 | PalaciosN_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/602 | https://bugsigdb.org/37314861 | curated and reviewed |
 | 4 | DuruIC_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/603 | https://bugsigdb.org/39143178 | curated and reviewed |
 | 5 | Metcalfe-RoachA_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/604 | https://bugsigdb.org/39192744 | curated and reviewed |
-| 6 | NishiwakiH_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/605 | https://bugsigdb.org/38773112  | curated and under review |
-| 7 | NuzumND_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/606 | https://bugsigdb.org/37150399  | curated and under review |
-| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/3585214 | curated and under review |
+| 6 | NishiwakiH_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/605 | https://bugsigdb.org/38773112  | curated and reviewed |
+| 7 | NuzumND_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/606 | https://bugsigdb.org/37150399  | curated and reviewed |
+| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/3585214 | curated and reviewed |
 
 
 ## December 2024

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ With the help of Svetlana and the Outreachy initiative, we are adding 8 new shot
 | 5 | Metcalfe-RoachA_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/604 | https://bugsigdb.org/39192744 | curated and reviewed |
 | 6 | NishiwakiH_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/605 | https://bugsigdb.org/38773112  | curated and reviewed |
 | 7 | NuzumND_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/606 | https://bugsigdb.org/37150399  | curated and reviewed |
-| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/3585214 | curated and reviewed |
+| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/35852145 | curated and reviewed |
 
 
 ## December 2024

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ This repository keeps track of the datasets found in the literature and the effo
 
 ### February 2025
 
-With the help of Svetlana and the Outreachie initiative, we are adding 8 new shotgun datasets to BugSigDB.
+With the help of Svetlana and the Outreachy initiative, we are adding 8 new shotgun datasets to BugSigDB.
+
+| Item | Study | GitHub issue | BugSigDB Study | Status |
+|---|---|---|---|
+| 1 | LiZ_2021 | https://github.com/waldronlab/BugSigDBcuration/issues/600 | https://bugsigdb.org/34276644 | curated and reviewed |
+| 2 | NieS_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/601 | https://bugsigdb.org/36995383 | curated and reviewed |
+| 3 | PalaciosN_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/602 | https://bugsigdb.org/37314861 | curated and reviewed |
+| 4 | DuruIC_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/603 | https://bugsigdb.org/39143178 | under curation |
+| 5 | Metcalfe-RoachA_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/604 | https://bugsigdb.org/39192744 | curated and under review |
+| 6 | NishiwakiH_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/605 | https://bugsigdb.org/38773112  | curated and under review |
+| 7 | NuzumND_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/606 | https://bugsigdb.org/37150399  | curated and under review |
+| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/3585214 | under curation |
+
 
 ## December 2024
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ With the help of Svetlana and the Outreachy initiative, we are adding 8 new shot
 | 1 | LiZ_2021 | https://github.com/waldronlab/BugSigDBcuration/issues/600 | https://bugsigdb.org/34276644 | curated and reviewed |
 | 2 | NieS_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/601 | https://bugsigdb.org/36995383 | curated and reviewed |
 | 3 | PalaciosN_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/602 | https://bugsigdb.org/37314861 | curated and reviewed |
-| 4 | DuruIC_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/603 | https://bugsigdb.org/39143178 | under curation |
-| 5 | Metcalfe-RoachA_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/604 | https://bugsigdb.org/39192744 | curated and under review |
+| 4 | DuruIC_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/603 | https://bugsigdb.org/39143178 | curated and reviewed |
+| 5 | Metcalfe-RoachA_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/604 | https://bugsigdb.org/39192744 | curated and reviewed |
 | 6 | NishiwakiH_2024 | https://github.com/waldronlab/BugSigDBcuration/issues/605 | https://bugsigdb.org/38773112  | curated and under review |
 | 7 | NuzumND_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/606 | https://bugsigdb.org/37150399  | curated and under review |
-| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/3585214 | under curation |
+| 8 | BolliriC_2022 | https://github.com/waldronlab/BugSigDBcuration/issues/607 | https://bugsigdb.org/3585214 | curated and under review |
 
 
 ## December 2024

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository keeps track of the datasets found in the literature and the effo
 With the help of Svetlana and the Outreachy initiative, we are adding 8 new shotgun datasets to BugSigDB.
 
 | Item | Study | GitHub issue | BugSigDB Study | Status |
-|---|---|---|---|
+|---|---|---|---|---|
 | 1 | LiZ_2021 | https://github.com/waldronlab/BugSigDBcuration/issues/600 | https://bugsigdb.org/34276644 | curated and reviewed |
 | 2 | NieS_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/601 | https://bugsigdb.org/36995383 | curated and reviewed |
 | 3 | PalaciosN_2023 | https://github.com/waldronlab/BugSigDBcuration/issues/602 | https://bugsigdb.org/37314861 | curated and reviewed |


### PR DESCRIPTION
Sharing a list of BugSigDB curated studies based on @g-antonello's selection:
```
Papers selected by Giacomo: 16
Preprints (BugSigDB does not accept preprints): 3
Papers with no significant differential abundance results to curate: 2
BugSigDB already curated: 3
BugSigDB additionally curated by Kate Rasheed, Svetlana Ugarcina Perovic and bugsigdb reviewers: 8
```
Our protocol for a flowchart of the selection process for eligible articles in the PubMed database:
**Identification:** https://pubmed.ncbi.nlm.nih.gov/?term=parkinson%2C+microbiome%2C+microbiota
**Screening:** manual screening for papers not already included in BugSigDB (until July 2024) with significant differential abundance results
**Included:** 42 papers <- sharing a list of our PD curation efforts by Outreachy contributors and Svetlana (since July 2024): https://github.com/waldronlab/BugSigDBcuration/issues?q=is%3Aissue%20state%3Aclosed%20parkinson%20label%3Areviewed

NOTE: we selected both amplicon and whole genome sequencing studies.